### PR TITLE
Anotação Pública para Autenticação JWT

### DIFF
--- a/src/models/user/user.controller.ts
+++ b/src/models/user/user.controller.ts
@@ -2,12 +2,14 @@ import { Controller, Post, Body, Patch, Param, Delete } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { Public } from 'src/common/decorator/publicDecorator';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post()
+  @Public()
   create(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(createUserDto);
   }


### PR DESCRIPTION
Utilizar o decorator @public para permitir que o endpoint de cadastro de usuário não seja considerado no handler global de autenticação JWT.